### PR TITLE
Install bash completion scripts and move gz tool scripts to non-dev package

### DIFF
--- a/ubuntu/debian/libsdformat-dev.install
+++ b/ubuntu/debian/libsdformat-dev.install
@@ -2,5 +2,3 @@ usr/include/*
 usr/lib/*/*.so
 usr/lib/*/pkgconfig/*.pc
 usr/lib/*/cmake/sdformat9/*
-usr/lib/ruby/ignition/*.rb
-usr/share/ignition/*.yaml

--- a/ubuntu/debian/libsdformat.install
+++ b/ubuntu/debian/libsdformat.install
@@ -1,1 +1,4 @@
 usr/lib/*/*.so.*
+usr/lib/ruby/ignition/*.rb
+usr/share/ignition/*.yaml
+usr/share/gz/*


### PR DESCRIPTION
Installs bash completion scripts to `usr/share/gz`. Also moves gz-tool scripts to non-dev deb packages (Toward https://github.com/gazebo-tooling/release-tools/issues/529)